### PR TITLE
Launch GitHub Actions runner in GUI context on macOS

### DIFF
--- a/kuiper-agent-lib/scripts/run_runner_gui_macos.sh
+++ b/kuiper-agent-lib/scripts/run_runner_gui_macos.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# GitHub Actions Runner GUI wrapper script for macOS
+# Runs the runner in Terminal.app context for GUI service access (code signing, keychain, etc.)
+
+LOG_FILE="$HOME/runner.log"
+EXIT_FILE="$HOME/runner-exit-status"
+
+# Clean up any previous run artifacts
+rm -f "$EXIT_FILE"
+echo "=== Runner started at $(date '+%Y-%m-%d %H:%M:%S') ===" > "$LOG_FILE"
+
+# Run the runner and capture output
+cd ~/actions-runner
+./run.sh >> "$LOG_FILE" 2>&1
+EXIT_CODE=$?
+
+# Record exit
+echo "=== Runner exited at $(date '+%Y-%m-%d %H:%M:%S') with code $EXIT_CODE ===" >> "$LOG_FILE"
+
+# Write exit code to signal file (atomically via temp + rename)
+echo "$EXIT_CODE" > "${EXIT_FILE}.tmp"
+mv "${EXIT_FILE}.tmp" "$EXIT_FILE"
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Implements Terminal.app-based runner launch for macOS GUI context access
- Inspired by Tartlet's approach to ensure code signing, keychain, and notarization work
- Runner polls for completion via signal files and streams logs

## Changes
- New `start_runner_gui_and_wait()` function launches runner via `open -a Terminal`
- Added `run_runner_gui_macos.sh` wrapper script (embedded at compile time)
- Updated VM manager to use GUI launch by default

🤖 Generated with Claude Code