### PR TITLE
Fix proxmox warn fail & agent vm max state mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "kuiper-agent-lib"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "kuiper-forge"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "kuiper-proxmox-agent"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "kuiper-proxmox-api"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "kuiper-tart-agent"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/kuiper-agent-lib/Cargo.toml
+++ b/kuiper-agent-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuiper-agent-lib"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version.workspace = true
 license.workspace = true

--- a/kuiper-agent-lib/src/connector.rs
+++ b/kuiper-agent-lib/src/connector.rs
@@ -4,6 +4,10 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 use tracing::{debug, info, warn};
 
 /// Configuration for connecting to the coordinator.
+///
+/// Note: this is connection-only config. The agent's labels, label_sets, and
+/// max_vms aren't here because they're sent in the first AgentStatus stream
+/// message (built by the agent itself), not at registration time.
 #[derive(Debug, Clone)]
 pub struct AgentConfig {
     /// gRPC URL of the coordinator (e.g., "https://coordinator.example.com:9443")
@@ -14,14 +18,6 @@ pub struct AgentConfig {
     pub registration_token: Option<String>,
     /// Agent type identifier ("tart" or "proxmox")
     pub agent_type: String,
-    /// Labels this agent advertises (legacy flat list)
-    pub labels: Vec<String>,
-    /// Label sets representing capabilities this agent can fulfill.
-    /// Each set is one capability (base labels + one image_mapping).
-    /// If non-empty, coordinator uses these instead of flat labels for matching.
-    pub label_sets: Vec<Vec<String>>,
-    /// Maximum concurrent VMs this agent can handle
-    pub max_vms: u32,
 }
 
 /// Handles connection to the coordinator with automatic registration and mTLS.
@@ -92,13 +88,16 @@ impl AgentConnector {
             .map(|h| h.to_string_lossy().to_string())
             .unwrap_or_else(|_| "unknown".to_string());
 
-        // Call Register RPC
+        // Call Register RPC. labels/max_vms are vestigial wire fields — kept
+        // for backward compatibility with older coordinators, but sent as
+        // defaults. The authoritative values come from the first AgentStatus
+        // stream message, and the coordinator syncs its stored record from that.
         let request = tonic::Request::new(RegisterRequest {
             registration_token: token.to_string(),
             hostname,
             agent_type: self.config.agent_type.clone(),
-            labels: self.config.labels.clone(),
-            max_vms: self.config.max_vms,
+            labels: Vec::new(),
+            max_vms: 0,
         });
 
         let response = reg_client

--- a/kuiper-agent-proto/proto/agent.proto
+++ b/kuiper-agent-proto/proto/agent.proto
@@ -20,6 +20,11 @@ message RegisterRequest {
     string registration_token = 1;
     string hostname = 2;
     string agent_type = 3;  // "tart" or "proxmox"
+    // Vestigial. The coordinator no longer reads these; the agent's labels
+    // and max_vms travel in the first AgentStatus stream message and the
+    // coordinator syncs its persisted record from there. Kept on the wire
+    // for backward compatibility with older agents/coordinators — new code
+    // sends defaults (empty / 0), old code's values are ignored on receive.
     repeated string labels = 4;
     uint32 max_vms = 5;
 }

--- a/kuiper-forge/Cargo.toml
+++ b/kuiper-forge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuiper-forge"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version.workspace = true
 license.workspace = true

--- a/kuiper-forge/src/agent_registry.rs
+++ b/kuiper-forge/src/agent_registry.rs
@@ -766,7 +766,9 @@ mod tests {
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 2);
 
         // Update to have 2 active VMs (no capacity)
-        registry.update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![])
+            .await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Should not find available agent now
@@ -801,22 +803,30 @@ mod tests {
 
         // Status update arrives with active_vms=0 (VMs not created yet)
         // This should NOT clear reserved_slots
-        registry.update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![])
+            .await;
 
         // Should still be at capacity
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Now VM is created - status update with active_vms=1
         // Should reduce reserved_slots by 1
-        registry.update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![])
+            .await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0); // 1 active + 1 reserved = 2
 
         // Second VM created
-        registry.update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![])
+            .await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0); // 2 active + 0 reserved
 
         // VM destroyed
-        registry.update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![])
+            .await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 1); // 1 active
     }
 
@@ -935,7 +945,9 @@ mod tests {
         // or VM creation failed internally on agent side).
         // active_vms went 1→0, reserved_slots=1, total=0+1=1 <= max_vms=2: no clamp.
         // This is correct: the in-flight command may still produce a VM.
-        registry.update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![])
+            .await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 1);
 
         // Now test a scenario where reserved_slots exceed physical possibility:
@@ -948,18 +960,24 @@ mod tests {
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Agent reports 1 active VM (one of our reserved slots materialized)
-        registry.update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![])
+            .await;
         // reserved=2-1=1, active=1, capacity=0
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Agent suddenly reports 2 active VMs (maybe another external runner started)
-        registry.update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![])
+            .await;
         // reserved=1-1=0, active=2, capacity=0
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Now VMs drop: active goes from 2→0. reserved_slots=0.
         // total = 0 + 0 = 0 <= max_vms=2. No clamping, capacity = 2.
-        registry.update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![]).await;
+        registry
+            .update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![])
+            .await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 2);
     }
 

--- a/kuiper-forge/src/agent_registry.rs
+++ b/kuiper-forge/src/agent_registry.rs
@@ -406,13 +406,52 @@ impl AgentRegistry {
         }
     }
 
-    /// Update agent status (active VMs, etc.)
-    pub async fn update_status(&self, agent_id: &str, active_vms: usize) {
+    /// Update agent status from a periodic AgentStatus message.
+    ///
+    /// Every field the agent reports (max_vms, labels, label_sets, active_vms)
+    /// is treated as the live truth — the agent's running config wins. This is
+    /// what lets a user edit the agent's config (e.g. `concurrent_vms`) and
+    /// have the coordinator pick up the new value without a full reconnect.
+    pub async fn update_status(
+        &self,
+        agent_id: &str,
+        active_vms: usize,
+        max_vms: usize,
+        labels: Vec<String>,
+        label_sets: Vec<Vec<String>>,
+    ) {
         if let Some(agent) = self.get(agent_id).await {
             let mut agent = agent.write().await;
             let old_active = agent.active_vms;
             let old_reserved = agent.reserved_slots;
+            let old_max = agent.max_vms;
             agent.active_vms = active_vms;
+
+            // Refresh fields that come from the agent's config so live config
+            // changes propagate. Logged at info! when max_vms changes since
+            // that affects scheduling capacity.
+            if old_max != max_vms {
+                info!(
+                    agent_id = %agent_id,
+                    old_max = old_max,
+                    new_max = max_vms,
+                    "Agent max_vms changed via status update"
+                );
+                agent.max_vms = max_vms;
+            }
+            if agent.labels != labels {
+                debug!(
+                    agent_id = %agent_id,
+                    old = ?agent.labels,
+                    new = ?labels,
+                    "Agent labels changed via status update"
+                );
+                agent.labels = labels;
+            }
+            if agent.label_sets != label_sets {
+                debug!(agent_id = %agent_id, "Agent label_sets changed via status update");
+                agent.label_sets = label_sets;
+            }
 
             if active_vms > old_active {
                 // VMs increased - some reserved slots materialized into active VMs.
@@ -727,7 +766,7 @@ mod tests {
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 2);
 
         // Update to have 2 active VMs (no capacity)
-        registry.update_status("agent_1", 2).await;
+        registry.update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![]).await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Should not find available agent now
@@ -762,22 +801,22 @@ mod tests {
 
         // Status update arrives with active_vms=0 (VMs not created yet)
         // This should NOT clear reserved_slots
-        registry.update_status("agent_1", 0).await;
+        registry.update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![]).await;
 
         // Should still be at capacity
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Now VM is created - status update with active_vms=1
         // Should reduce reserved_slots by 1
-        registry.update_status("agent_1", 1).await;
+        registry.update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![]).await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0); // 1 active + 1 reserved = 2
 
         // Second VM created
-        registry.update_status("agent_1", 2).await;
+        registry.update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![]).await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0); // 2 active + 0 reserved
 
         // VM destroyed
-        registry.update_status("agent_1", 1).await;
+        registry.update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![]).await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 1); // 1 active
     }
 
@@ -896,7 +935,7 @@ mod tests {
         // or VM creation failed internally on agent side).
         // active_vms went 1→0, reserved_slots=1, total=0+1=1 <= max_vms=2: no clamp.
         // This is correct: the in-flight command may still produce a VM.
-        registry.update_status("agent_1", 0).await;
+        registry.update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![]).await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 1);
 
         // Now test a scenario where reserved_slots exceed physical possibility:
@@ -909,18 +948,18 @@ mod tests {
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Agent reports 1 active VM (one of our reserved slots materialized)
-        registry.update_status("agent_1", 1).await;
+        registry.update_status("agent_1", 1, 2, vec!["macos".to_string()], vec![]).await;
         // reserved=2-1=1, active=1, capacity=0
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Agent suddenly reports 2 active VMs (maybe another external runner started)
-        registry.update_status("agent_1", 2).await;
+        registry.update_status("agent_1", 2, 2, vec!["macos".to_string()], vec![]).await;
         // reserved=1-1=0, active=2, capacity=0
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 0);
 
         // Now VMs drop: active goes from 2→0. reserved_slots=0.
         // total = 0 + 0 = 0 <= max_vms=2. No clamping, capacity = 2.
-        registry.update_status("agent_1", 0).await;
+        registry.update_status("agent_1", 0, 2, vec!["macos".to_string()], vec![]).await;
         assert_eq!(registry.available_capacity(&["macos".to_string()]).await, 2);
     }
 

--- a/kuiper-forge/src/auth.rs
+++ b/kuiper-forge/src/auth.rs
@@ -356,15 +356,21 @@ impl AuthManager {
         Ok(reg_token)
     }
 
-    /// Exchange registration token for client certificate
+    /// Exchange registration token for client certificate.
+    ///
+    /// The agent's labels and max_vms are not parameters: those come from the
+    /// first AgentStatus stream message after the agent connects, and the
+    /// persisted record is synced from there. The record created here starts
+    /// with empty labels and zero max_vms — placeholders that live for the
+    /// brief window until the agent first connects with its real config.
     pub async fn exchange_token_for_certificate(
         &self,
         token: &str,
         hostname: &str,
         agent_type: &str,
-        labels: Vec<String>,
-        max_vms: u32,
     ) -> Result<AgentCertificate> {
+        let labels: Vec<String> = Vec::new();
+        let max_vms: u32 = 0;
         // 1. Consume the token (single-use)
         let reg_token = self
             .store
@@ -474,6 +480,13 @@ impl AuthManager {
     #[allow(dead_code)]
     pub async fn get_agent(&self, agent_id: &str) -> Option<RegisteredAgent> {
         self.store.get_agent(agent_id).await
+    }
+
+    /// Persist (upsert) an agent record. Used to keep the stored record in sync
+    /// with the live state an agent reports on stream connect — bootstrap values
+    /// from initial registration are otherwise never updated.
+    pub async fn store_agent(&self, agent: RegisteredAgent) -> Result<()> {
+        self.store.store_agent(agent).await
     }
 }
 

--- a/kuiper-forge/src/auth.rs
+++ b/kuiper-forge/src/auth.rs
@@ -186,6 +186,26 @@ impl AuthStore {
         }
     }
 
+    /// Update only the fields an agent reports via AgentStatus (labels and
+    /// max_vms). Leaves `revoked` and other admin-controlled columns untouched,
+    /// so a concurrent revoke between read and write can't be undone by this
+    /// path.
+    pub async fn update_agent_metadata(
+        &self,
+        agent_id: &str,
+        labels: &[String],
+        max_vms: u32,
+    ) -> Result<()> {
+        let labels_json = serde_json::to_string(labels)?;
+        sqlx::query(sql::UPDATE_AGENT_METADATA)
+            .bind(&labels_json)
+            .bind(max_vms as i64)
+            .bind(agent_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Store a registered agent
     pub async fn store_agent(&self, agent: RegisteredAgent) -> Result<()> {
         let labels_json = serde_json::to_string(&agent.labels)?;
@@ -482,11 +502,18 @@ impl AuthManager {
         self.store.get_agent(agent_id).await
     }
 
-    /// Persist (upsert) an agent record. Used to keep the stored record in sync
-    /// with the live state an agent reports on stream connect — bootstrap values
-    /// from initial registration are otherwise never updated.
-    pub async fn store_agent(&self, agent: RegisteredAgent) -> Result<()> {
-        self.store.store_agent(agent).await
+    /// Update only labels and max_vms on a stored agent record. Preserves the
+    /// `revoked` flag so an admin revocation that lands concurrently with this
+    /// update isn't clobbered.
+    pub async fn update_agent_metadata(
+        &self,
+        agent_id: &str,
+        labels: &[String],
+        max_vms: u32,
+    ) -> Result<()> {
+        self.store
+            .update_agent_metadata(agent_id, labels, max_vms)
+            .await
     }
 }
 

--- a/kuiper-forge/src/server.rs
+++ b/kuiper-forge/src/server.rs
@@ -203,19 +203,18 @@ impl RegistrationService for RegistrationServiceImpl {
         info!(
             hostname = %req.hostname,
             agent_type = %req.agent_type,
-            labels = ?req.labels,
             "Agent registration request"
         );
 
-        // Exchange token for certificate
+        // Exchange token for certificate. labels/max_vms are no longer carried in
+        // RegisterRequest — they come from the first AgentStatus stream message
+        // and the coordinator syncs its persisted record from that live value.
         let cert = self
             .auth_manager
             .exchange_token_for_certificate(
                 &req.registration_token,
                 &req.hostname,
                 &req.agent_type,
-                req.labels,
-                req.max_vms,
             )
             .await
             .map_err(|e| {
@@ -411,6 +410,32 @@ impl AgentService for AgentServiceImpl {
             "Agent stream connected"
         );
 
+        // Keep the persisted agent record in sync with what the agent actually
+        // reports. The registration-time max_vms/labels are bootstrap placeholders;
+        // the live status message is the truth, so the admin UI / CLI / DB query
+        // surfaces should reflect it. The in-memory registry is handled by
+        // agent_registry.register() below.
+        if let Some(mut stored) = self.auth_manager.get_agent(&agent_id).await {
+            let new_max = max_vms as u32;
+            let labels_changed = stored.labels != labels;
+            let max_changed = stored.max_vms != new_max;
+            if labels_changed || max_changed {
+                info!(
+                    agent_id = %agent_id,
+                    old_max = stored.max_vms,
+                    new_max = new_max,
+                    labels_changed = labels_changed,
+                    "Syncing persisted agent record from live status"
+                );
+                stored.max_vms = new_max;
+                stored.labels = labels.clone();
+                if let Err(e) = self.auth_manager.store_agent(stored).await {
+                    warn!(error = %e, agent_id = %agent_id,
+                          "Failed to persist updated agent record");
+                }
+            }
+        }
+
         // Create channel for outbound messages
         let (outbound_tx, outbound_rx) = mpsc::channel::<Result<CoordinatorMessage, Status>>(32);
 
@@ -545,8 +570,21 @@ async fn handle_agent_message(
                 vm_count = status.vms.len(),
                 "Agent status update"
             );
+            // Pass every config-derived field so live agent config changes
+            // propagate to the coordinator without needing a full reconnect.
+            let label_sets: Vec<Vec<String>> = status
+                .label_sets
+                .iter()
+                .map(|ls| ls.labels.clone())
+                .collect();
             registry
-                .update_status(agent_id, status.active_vms as usize)
+                .update_status(
+                    agent_id,
+                    status.active_vms as usize,
+                    status.max_vms as usize,
+                    status.labels.clone(),
+                    label_sets,
+                )
                 .await;
 
             // Reconcile persisted runner state against the agent's current VM list

--- a/kuiper-forge/src/server.rs
+++ b/kuiper-forge/src/server.rs
@@ -211,11 +211,7 @@ impl RegistrationService for RegistrationServiceImpl {
         // and the coordinator syncs its persisted record from that live value.
         let cert = self
             .auth_manager
-            .exchange_token_for_certificate(
-                &req.registration_token,
-                &req.hostname,
-                &req.agent_type,
-            )
+            .exchange_token_for_certificate(&req.registration_token, &req.hostname, &req.agent_type)
             .await
             .map_err(|e| {
                 warn!(error = %e, "Registration failed");

--- a/kuiper-forge/src/server.rs
+++ b/kuiper-forge/src/server.rs
@@ -415,7 +415,11 @@ impl AgentService for AgentServiceImpl {
         // the live status message is the truth, so the admin UI / CLI / DB query
         // surfaces should reflect it. The in-memory registry is handled by
         // agent_registry.register() below.
-        if let Some(mut stored) = self.auth_manager.get_agent(&agent_id).await {
+        //
+        // Uses a targeted UPDATE that only touches labels/max_vms, not a full
+        // upsert — that way a concurrent admin `revoke_agent` between our read
+        // and write can't be silently undone by this path.
+        if let Some(stored) = self.auth_manager.get_agent(&agent_id).await {
             let new_max = max_vms as u32;
             let labels_changed = stored.labels != labels;
             let max_changed = stored.max_vms != new_max;
@@ -427,9 +431,11 @@ impl AgentService for AgentServiceImpl {
                     labels_changed = labels_changed,
                     "Syncing persisted agent record from live status"
                 );
-                stored.max_vms = new_max;
-                stored.labels = labels.clone();
-                if let Err(e) = self.auth_manager.store_agent(stored).await {
+                if let Err(e) = self
+                    .auth_manager
+                    .update_agent_metadata(&agent_id, &labels, new_max)
+                    .await
+                {
                     warn!(error = %e, agent_id = %agent_id,
                           "Failed to persist updated agent record");
                 }

--- a/kuiper-forge/src/sql.rs
+++ b/kuiper-forge/src/sql.rs
@@ -93,6 +93,17 @@ pub const REVOKE_AGENT: &str = "UPDATE registered_agents SET revoked = 1 WHERE a
 #[cfg(feature = "postgres")]
 pub const REVOKE_AGENT: &str = "UPDATE registered_agents SET revoked = 1 WHERE agent_id = $1";
 
+/// Targeted update for the fields an agent can change at runtime via AgentStatus
+/// (labels, max_vms). Critically does NOT touch `revoked`, so a concurrent
+/// `revoke_agent` between read-modify-write can't be silently undone.
+#[cfg(feature = "sqlite")]
+pub const UPDATE_AGENT_METADATA: &str =
+    "UPDATE registered_agents SET labels = ?, max_vms = ? WHERE agent_id = ?";
+
+#[cfg(feature = "postgres")]
+pub const UPDATE_AGENT_METADATA: &str =
+    "UPDATE registered_agents SET labels = $1, max_vms = $2 WHERE agent_id = $3";
+
 #[cfg(feature = "sqlite")]
 pub const CHECK_AGENT_VALID: &str =
     "SELECT 1 FROM registered_agents WHERE agent_id = ? AND revoked = 0 AND expires_at > ?";

--- a/kuiper-forge/tests/grpc_mtls_test.rs
+++ b/kuiper-forge/tests/grpc_mtls_test.rs
@@ -223,8 +223,8 @@ async fn test_grpc_tls_connection_grpc_only_mode() {
             registration_token: "invalid-token".to_string(),
             hostname: "test-host".to_string(),
             agent_type: "tart".to_string(),
-            labels: vec!["test".to_string()],
-            max_vms: 2,
+            labels: vec![],
+            max_vms: 0,
         })
         .await;
 
@@ -260,7 +260,7 @@ async fn test_agent_service_requires_mtls_grpc_only_mode() {
             agent_id: "test-agent".to_string(),
             hostname: "test-host".to_string(),
             agent_type: "tart".to_string(),
-            labels: vec!["test".to_string()],
+            labels: vec![],
             max_vms: 2,
             label_sets: vec![],
         })),
@@ -305,8 +305,8 @@ async fn test_grpc_tls_connection_webhook_mode() {
             registration_token: "invalid-token".to_string(),
             hostname: "test-host".to_string(),
             agent_type: "tart".to_string(),
-            labels: vec!["test".to_string()],
-            max_vms: 2,
+            labels: vec![],
+            max_vms: 0,
         })
         .await;
 
@@ -341,7 +341,7 @@ async fn test_agent_service_requires_mtls_webhook_mode() {
             agent_id: "test-agent".to_string(),
             hostname: "test-host".to_string(),
             agent_type: "tart".to_string(),
-            labels: vec!["test".to_string()],
+            labels: vec![],
             max_vms: 2,
             label_sets: vec![],
         })),

--- a/kuiper-proxmox-agent/Cargo.toml
+++ b/kuiper-proxmox-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuiper-proxmox-agent"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2024"
 rust-version.workspace = true
 license.workspace = true
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 kuiper-agent-proto = { version = "0.2.0", path = "../kuiper-agent-proto" }
-kuiper-agent-lib = { version = "0.2.0", path = "../kuiper-agent-lib" }
-kuiper-proxmox-api = { version = "0.1.0", path = "../kuiper-proxmox-api" }
+kuiper-agent-lib = { version = "0.3.0", path = "../kuiper-agent-lib" }
+kuiper-proxmox-api = { version = "0.1.2", path = "../kuiper-proxmox-api" }
 
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/kuiper-proxmox-agent/src/config.rs
+++ b/kuiper-proxmox-agent/src/config.rs
@@ -312,7 +312,7 @@ impl Config {
                 template_vmid: 9000,
                 storage: "local-lvm".to_string(),
                 linked_clone: true,
-                concurrent_vms: 5,
+                concurrent_vms: default_concurrent_vms(),
                 ip_timeout_secs: default_ip_timeout(),
                 clone_timeout_secs: default_clone_timeout(),
                 template_mappings: vec![],

--- a/kuiper-proxmox-agent/src/main.rs
+++ b/kuiper-proxmox-agent/src/main.rs
@@ -453,6 +453,30 @@ impl ProxmoxAgent {
             }
         });
 
+        // Push a status update on every VM-set transition (insert/remove). This
+        // closes the gap between accepting a CreateRunner and the coordinator's
+        // next periodic status tick — without it, the coordinator's `active_vms`
+        // view lags by up to 30s, and reserve_slot accounting can leak via
+        // release-on-reject and cause retry storms.
+        let transition_tx = tx.clone();
+        let transition_agent = Arc::clone(self);
+        let transition_notify = self.vm_manager.state_changes();
+        let transition_handle = tokio::spawn(async move {
+            loop {
+                transition_notify.notified().await;
+                let status = transition_agent.build_status().await;
+                if transition_tx
+                    .send(AgentMessage {
+                        payload: Some(AgentPayload::Status(status)),
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
         // Process messages from coordinator
         while let Some(msg) = inbound.message().await.transpose() {
             match msg {
@@ -463,14 +487,16 @@ impl ProxmoxAgent {
                 Err(e) => {
                     error!("Stream error: {}", e);
                     status_handle.abort();
+                    transition_handle.abort();
                     return Err(Error::Grpc(e));
                 }
             }
         }
         info!("Stream closed by coordinator");
 
-        // Clean up status task when stream closes
+        // Clean up status tasks when stream closes
         status_handle.abort();
+        transition_handle.abort();
 
         Ok(())
     }
@@ -499,9 +525,10 @@ impl ProxmoxAgent {
                 // Check capacity before acking - reject early if at max VMs
                 if !self.vm_manager.has_capacity().await {
                     let max = self.config.vm.concurrent_vms;
+                    let active = self.vm_manager.active_count().await;
                     warn!(
                         "Rejecting CreateRunner for vm={}: at capacity ({}/{})",
-                        cmd.vm_name, max, max
+                        cmd.vm_name, active, max
                     );
                     send_command_ack(
                         tx,

--- a/kuiper-proxmox-agent/src/main.rs
+++ b/kuiper-proxmox-agent/src/main.rs
@@ -198,15 +198,13 @@ async fn cmd_register(bundle_token: &str, config_path: &Path) -> anyhow::Result<
         .and_then(|u| u.host_str().map(String::from))
         .unwrap_or_else(|| "localhost".to_string());
 
-    // 4. Build agent config for registration
+    // 4. Build agent config for registration. labels/max_vms aren't here —
+    // they're sent in the first AgentStatus when the daemon connects.
     let agent_config = kuiper_agent_lib::AgentConfig {
         coordinator_url: bundle.coordinator_url.clone(),
         coordinator_hostname: hostname.clone(),
         registration_token: Some(bundle.token),
         agent_type: "proxmox".to_string(),
-        labels: vec![],     // Empty for registration - user will set in config
-        label_sets: vec![], // Empty for registration - user will set in config
-        max_vms: 5,         // Default - user will set in config
     };
 
     // 5. Connect and register
@@ -380,18 +378,13 @@ impl ProxmoxAgent {
 
     /// Connect to coordinator and run the agent loop.
     async fn connect_and_run(self: &Arc<Self>) -> Result<()> {
-        // Create agent config for connector
-        // Use registration token from CLI args (for first-time registration)
-        // For proxmox, label_sets is just a single set containing the configured labels
-        let labels = self.config.agent.labels.clone();
+        // Connection-only config. labels and max_vms travel in the first
+        // AgentStatus stream message (see build_status), not here.
         let agent_config = LibAgentConfig {
             coordinator_url: self.config.coordinator.url.clone(),
             coordinator_hostname: self.config.coordinator.hostname.clone(),
             registration_token: None, // Already registered, using stored certificates
             agent_type: "proxmox".to_string(),
-            labels: labels.clone(),
-            label_sets: vec![labels], // Single capability set
-            max_vms: self.config.vm.concurrent_vms,
         };
 
         // Connect to coordinator using stored cert_store

--- a/kuiper-proxmox-agent/src/vm_manager.rs
+++ b/kuiper-proxmox-agent/src/vm_manager.rs
@@ -14,7 +14,7 @@ use kuiper_proxmox_api::ProxmoxVEAPI;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 use tracing::{debug, error, info, warn};
 
 /// Parameters for configuring a GitHub Actions runner on a VM.
@@ -82,6 +82,10 @@ pub struct VmManager {
     ssh_config: SshConfig,
     /// Currently active VMs
     active_vms: Arc<RwLock<HashMap<u32, VmInstance>>>,
+    /// Notifier fired whenever the active VM set changes (insert/remove).
+    /// Subscribers can use this to push immediate AgentStatus updates so the
+    /// coordinator's view doesn't lag the agent's true capacity.
+    state_changed: Arc<Notify>,
 }
 
 impl VmManager {
@@ -92,7 +96,14 @@ impl VmManager {
             vm_config,
             ssh_config,
             active_vms: Arc::new(RwLock::new(HashMap::new())),
+            state_changed: Arc::new(Notify::new()),
         }
+    }
+
+    /// Get the notifier for active-VM-set changes. Each call to `notified()`
+    /// awaits the next insert/remove on `active_vms`.
+    pub fn state_changes(&self) -> Arc<Notify> {
+        self.state_changed.clone()
     }
 
     /// Get the number of active VMs.
@@ -140,6 +151,7 @@ impl VmManager {
             created_at: Instant::now(),
         };
         self.active_vms.write().await.insert(vmid, instance.clone());
+        self.state_changed.notify_one();
 
         // Clone the template
         let storage = if self.vm_config.storage.is_empty() {
@@ -161,8 +173,10 @@ impl VmManager {
             .inspect_err(|_e| {
                 // Remove from tracking on failure
                 let vms = self.active_vms.clone();
+                let notify = self.state_changed.clone();
                 tokio::spawn(async move {
                     vms.write().await.remove(&vmid);
+                    notify.notify_one();
                 });
             })?;
 
@@ -173,8 +187,10 @@ impl VmManager {
             .await
             .inspect_err(|_e| {
                 let vms = self.active_vms.clone();
+                let notify = self.state_changed.clone();
                 tokio::spawn(async move {
                     vms.write().await.remove(&vmid);
+                    notify.notify_one();
                 });
             })?;
 
@@ -583,6 +599,7 @@ impl VmManager {
 
         // Remove from tracking
         self.active_vms.write().await.remove(&vmid);
+        self.state_changed.notify_one();
 
         info!("VM {} destroyed", vmid);
         Ok(())

--- a/kuiper-proxmox-api/Cargo.toml
+++ b/kuiper-proxmox-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuiper-proxmox-api"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2024"
 rust-version.workspace = true
 license.workspace = true

--- a/kuiper-proxmox-api/src/lib.rs
+++ b/kuiper-proxmox-api/src/lib.rs
@@ -5,7 +5,7 @@ use std::ffi::OsString;
 use std::fmt::Debug;
 use std::process::Command;
 use std::time::Duration;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Deserialize)]
 struct VmResponse {
@@ -497,15 +497,18 @@ impl ProxmoxVEAPI {
 
             match status.status.as_str() {
                 "stopped" => {
-                    if let Some(exit) = &status.exitstatus {
-                        if exit == "OK" {
+                    // Proxmox tasks report an `exitstatus` string. "OK" is a clean
+                    // success; "WARNINGS: N" means the task *succeeded* but emitted
+                    // warnings (e.g. the benign UEFI 2023 cert notice on VM start).
+                    // Only a non-OK, non-WARNINGS status is an actual failure.
+                    match status.exitstatus.as_deref() {
+                        Some("OK") | None => return Ok(()),
+                        Some(exit) if exit.starts_with("WARNINGS:") => {
+                            warn!("Task {upid} completed with warnings: {exit}");
                             return Ok(());
-                        } else {
-                            return Err(Error::TaskFailed(exit.clone()));
                         }
+                        Some(exit) => return Err(Error::TaskFailed(exit.to_string())),
                     }
-                    // No exitstatus but stopped - assume success
-                    return Ok(());
                 }
                 "running" => {
                     tokio::time::sleep(Duration::from_millis(500)).await;

--- a/kuiper-tart-agent/Cargo.toml
+++ b/kuiper-tart-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuiper-tart-agent"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 kuiper-agent-proto = { version = "0.2.0", path = "../kuiper-agent-proto" }
-kuiper-agent-lib = { version = "0.2.0", path = "../kuiper-agent-lib" }
+kuiper-agent-lib = { version = "0.3.0", path = "../kuiper-agent-lib" }
 
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/kuiper-tart-agent/src/main.rs
+++ b/kuiper-tart-agent/src/main.rs
@@ -683,6 +683,29 @@ impl TartAgent {
         // when VMs complete so it can clean up the associated runners from GitHub
         let status_tx = tx.clone();
         let status_agent = Arc::clone(self);
+        // Push a status update on every VM-set transition (insert/remove). This
+        // closes the gap between accepting a CreateRunner and the coordinator's
+        // next periodic status tick — without it, the coordinator's `active_vms`
+        // view lags by up to 30s and reserve_slot accounting can leak via
+        // release-on-reject and cause retry storms.
+        let transition_tx = tx.clone();
+        let transition_agent = Arc::clone(self);
+        let transition_notify = self.vm_manager.state_changes();
+        let transition_handle = tokio::spawn(async move {
+            loop {
+                transition_notify.notified().await;
+                let status = transition_agent.build_status().await;
+                if transition_tx
+                    .send(AgentMessage {
+                        payload: Some(AgentPayload::Status(status)),
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
         let status_handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(30));
             // Skip the first tick since we already sent initial status
@@ -717,14 +740,16 @@ impl TartAgent {
                 Some(Err(e)) => {
                     error!("Error receiving message: {}", e);
                     status_handle.abort();
+                    transition_handle.abort();
                     return Err(Error::Status(e));
                 }
                 None => break,
             }
         }
 
-        // Clean up status task when stream closes
+        // Clean up status tasks when stream closes
         status_handle.abort();
+        transition_handle.abort();
 
         warn!("Stream closed by coordinator");
         Ok(())
@@ -750,9 +775,10 @@ impl TartAgent {
                     // Check capacity before acking - reject early if at max VMs
                     if agent.vm_manager.available_slots().await == 0 {
                         let max = agent.vm_manager.max_vms();
+                        let active = agent.vm_manager.active_count().await;
                         warn!(
                             "Rejecting CreateRunner for vm={}: at capacity ({}/{})",
-                            cmd.vm_name, max, max
+                            cmd.vm_name, active, max
                         );
                         send_command_ack(
                             &tx,

--- a/kuiper-tart-agent/src/main.rs
+++ b/kuiper-tart-agent/src/main.rs
@@ -244,19 +244,26 @@ async fn main() -> anyhow::Result<()> {
     // Initialize certificate store
     let cert_store = AgentCertStore::new(config.tls.certs_dir.clone());
 
-    // Build agent connector config
+    // Connection-only config. The advertised labels, label_sets, and max_vms
+    // travel in the first AgentStatus stream message (built by TartAgent), not
+    // here — so the coordinator always sees the current values from config.
     let agent_config = AgentConfig {
         coordinator_url: config.coordinator.url.clone(),
         coordinator_hostname: config.coordinator.hostname.clone(),
         registration_token: None, // Already registered, using stored certificates
         agent_type: "tart".to_string(),
-        labels: base_labels,
-        label_sets,
-        max_vms: config.tart.max_concurrent_vms,
     };
 
-    // Create agent instance
-    let agent = TartAgent::new(agent_config, cert_store, vm_manager.clone(), config.clone());
+    // Create agent instance. Pass the agent-level metadata (labels, label_sets)
+    // through; max_vms is read from config.tart.max_concurrent_vms in build_status.
+    let agent = TartAgent::new(
+        agent_config,
+        cert_store,
+        vm_manager.clone(),
+        config.clone(),
+        base_labels,
+        label_sets,
+    );
 
     // Spawn cleanup task
     let cleanup_vm_manager = vm_manager.clone();
@@ -326,15 +333,13 @@ async fn cmd_register(bundle_token: &str, config_path: &Path) -> anyhow::Result<
         .and_then(|u| u.host_str().map(String::from))
         .unwrap_or_else(|| "localhost".to_string());
 
-    // 4. Build agent config for registration
+    // 4. Build agent config for registration. labels/max_vms aren't here —
+    // they're sent in the first AgentStatus when the daemon connects.
     let agent_config = kuiper_agent_lib::AgentConfig {
         coordinator_url: bundle.coordinator_url.clone(),
         coordinator_hostname: hostname.clone(),
         registration_token: Some(bundle.token),
         agent_type: "tart".to_string(),
-        labels: vec![],     // Empty for registration - user will set in config
-        label_sets: vec![], // Empty for registration - derived from image_mappings
-        max_vms: 2,         // Default - user will set in config
     };
 
     // 5. Connect and register
@@ -547,6 +552,10 @@ struct TartAgent {
     cert_store: AgentCertStore,
     vm_manager: Arc<VmManager>,
     config: Config,
+    /// Base labels this agent advertises (flat list; sent in AgentStatus).
+    labels: Vec<String>,
+    /// Capability sets derived from image_mappings (sent in AgentStatus).
+    label_sets: Vec<Vec<String>>,
 }
 
 async fn send_command_ack(
@@ -597,12 +606,16 @@ impl TartAgent {
         cert_store: AgentCertStore,
         vm_manager: Arc<VmManager>,
         config: Config,
+        labels: Vec<String>,
+        label_sets: Vec<Vec<String>>,
     ) -> Arc<Self> {
         Arc::new(Self {
             agent_config,
             cert_store,
             vm_manager,
             config,
+            labels,
+            label_sets,
         })
     }
 
@@ -1034,7 +1047,6 @@ impl TartAgent {
 
         // Convert Vec<Vec<String>> to Vec<LabelSet>
         let label_sets: Vec<LabelSet> = self
-            .agent_config
             .label_sets
             .iter()
             .map(|ls| LabelSet { labels: ls.clone() })
@@ -1048,8 +1060,8 @@ impl TartAgent {
             agent_id: self.cert_store.get_agent_id().unwrap_or_default(),
             hostname,
             agent_type: self.agent_config.agent_type.clone(),
-            labels: self.agent_config.labels.clone(),
-            max_vms: self.agent_config.max_vms,
+            labels: self.labels.clone(),
+            max_vms: self.config.tart.max_concurrent_vms,
             label_sets,
         }
     }

--- a/kuiper-tart-agent/src/vm_manager.rs
+++ b/kuiper-tart-agent/src/vm_manager.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use kuiper_agent_proto::VmInfo;
 use tokio::process::Command;
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 use tokio::time::{Instant, timeout};
 
 /// Timeout for tart CLI commands (clone, stop, delete, ip).
@@ -92,6 +92,10 @@ pub struct VmManager {
     active_vms: Arc<RwLock<HashMap<String, VmState>>>,
     /// Directory for runner log files
     log_dir: PathBuf,
+    /// Notifier fired whenever the active VM set changes (insert/remove).
+    /// Used by the agent's main loop to push immediate AgentStatus updates so
+    /// the coordinator's view doesn't lag the agent's true capacity.
+    state_changed: Arc<Notify>,
 }
 
 impl VmManager {
@@ -104,7 +108,14 @@ impl VmManager {
             max_concurrent,
             active_vms: Arc::new(RwLock::new(HashMap::new())),
             log_dir,
+            state_changed: Arc::new(Notify::new()),
         }
+    }
+
+    /// Get the notifier for active-VM-set changes. Each call to `notified()`
+    /// awaits the next insert/remove on `active_vms`.
+    pub fn state_changes(&self) -> Arc<Notify> {
+        self.state_changed.clone()
     }
 
     /// Get the number of active VMs.
@@ -162,6 +173,7 @@ impl VmManager {
             .write()
             .await
             .insert(vm_name.to_string(), vm_state);
+        self.state_changed.notify_one();
 
         // Clone the VM
         match self.tart_clone(template, vm_name).await {
@@ -171,6 +183,7 @@ impl VmManager {
             Err(e) => {
                 // Remove from tracking on failure
                 self.active_vms.write().await.remove(vm_name);
+                self.state_changed.notify_one();
                 return Err(e);
             }
         }
@@ -186,6 +199,7 @@ impl VmManager {
                 // Cleanup on failure
                 let _ = self.tart_delete(vm_name).await;
                 self.active_vms.write().await.remove(vm_name);
+                self.state_changed.notify_one();
                 return Err(e);
             }
         }
@@ -338,6 +352,7 @@ impl VmManager {
 
         // Remove from tracking
         self.active_vms.write().await.remove(vm_id);
+        self.state_changed.notify_one();
 
         Ok(())
     }


### PR DESCRIPTION
- Proxmox VM start can produce warnings like for EFI key enroll warnings, agent would think it's a failure
- kuiper-forge coordinator wouldn't always have an up-to-date view of capacity of agents, agents now report changes to this immediately